### PR TITLE
check if the element in the loop is a string

### DIFF
--- a/url.js
+++ b/url.js
@@ -96,7 +96,7 @@ var get = self["get"] = function(q, opt)
 	var c = q.split("&");
 	for ( var i in c )
 	{
-		if (!c[i].length) continue;
+		if (!c[i].length || typeof c[i] !== 'string') continue;
 		
 		var d = c[i].indexOf("=");
 		var k = c[i], v = true;


### PR DESCRIPTION
`for ( var i in c )` loops on all attributes of the array. Attributes could be `functions` or other types of things. Check if the element is a string before going on in the loop to prevent `TypeError: c[i].indexOf is not a function` errors.
